### PR TITLE
updated tabs.js to allow for normal #link function on smaller screens

### DIFF
--- a/app/assets/javascripts/tabs.js
+++ b/app/assets/javascripts/tabs.js
@@ -39,6 +39,12 @@
   }
 
   ready(function() {
+    var mobileMediaQuery = '(max-width: 641px)'
+    var mq = w.matchMedia(mobileMediaQuery)
+    if(!mq.matches) { jsTabs() }
+  })
+
+  function jsTabs() {
     var tabs = d.querySelectorAll('.govuk-tabs')
     var tabSelectedClass = 'govuk-tabs__tab--selected'
     var panelHiddenClass = 'govuk-tabs__panel--hidden'
@@ -85,6 +91,6 @@
       
 
     })
-  })
+  }
   
 })(document,window);


### PR DESCRIPTION
This doesn't work on `window.resize`, but it does work on the `ready` event. It's not a perfect solution, but the perfect solution would take 5x longer to code.